### PR TITLE
Alter default location of git-options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,10 @@ used (mainly shell/eshell).
 install
 -------
 
-Place file ``pcmpl-git.el`` in ``load-path`` and ``git-options`` in
-``data-directory`` by default. You can put file ``git-options``
-anywhere and customise ``pcmpl-git-options-file`` to point to it.
+Place files ``pcmpl-git.el`` and ``git-options`` in ``load-path``.
+By default, ``git-options`` will be looked for in the same directory
+as ``pcmpl-git.el``. You can put the file ``git-options`` anywhere
+and customise ``pcmpl-git-options-file`` to point to it.
 
 File ``pcmpl-git-parse.el`` is not needed for running this package. It
 is used for generating ``git-options``.

--- a/pcmpl-git.el
+++ b/pcmpl-git.el
@@ -36,8 +36,14 @@
   :type 'file
   :group 'pcomplete)
 
+(defcustom pcmpl-git-data-directory
+  (file-name-directory load-file-name)
+  "Default directory used for locating the `pcmpl-git-options-file'."
+  :type 'directory
+  :group 'pcomplete)
+
 (defcustom pcmpl-git-options-file
-  (expand-file-name "git-options" data-directory)
+  (expand-file-name "git-options" pcmpl-git-data-directory)
   "File containing a hashtable with git options."
   :type 'file
   :group 'pcomplete)


### PR DESCRIPTION
By searching for `git-options` in the same directory as `pcmpl-git.el` by default, it will be possible for me to create a [MELPA](https://github.com/milkypostman/melpa) recipe that works out of the box for end users. All of a package's files are installed to the same directory, and defaulting to searching for `git-options` in `data-directory` means that completion of subcommand options will not work without the user customizing the `pcmpl-git-options-file` variable.

Thanks for this library, I use it pretty much every single day, and it helps a lot when I can't remember git's consistently obscure option names. =)
