### PR TITLE
Fix using free variable issue

### DIFF
--- a/pcmpl-git-parse.el
+++ b/pcmpl-git-parse.el
@@ -34,7 +34,7 @@
 Normally it is the 'Documentation' direcotry under top-level git source.")
 
 (defun git-parse-config ()
-  (let (variables (config (expand-file-name "config.txt" git-documentation-dir)))
+  (let (variables include (config (expand-file-name "config.txt" git-documentation-dir)))
     (when (file-exists-p config)
       (with-temp-buffer
         (insert-file-contents config)


### PR DESCRIPTION
Declare it as local variable.

There are following byte-compile warnings.

```
In git-parse-config:                                                              
pcmpl-git-parse.el:45:17:Warning: assignment to free variable `include'
pcmpl-git-parse.el:45:43:Warning: reference to free variable `include'
```
